### PR TITLE
set app name based on executable

### DIFF
--- a/test.py
+++ b/test.py
@@ -1,20 +1,23 @@
-#!/usr/bin/python3 
-
+#!/usr/bin/python3
+import os
 import sys
 
 from qgis.core import (
-     QgsApplication, 
-     QgsProcessingFeedback, 
+     QgsApplication,
+     QgsProcessingFeedback,
      QgsVectorLayer
 )
 
-# See https://gis.stackexchange.com/a/155852/4972 for details about the prefix 
-QgsApplication.setPrefixPath("/Applications/QGIS.app/Contents/MacOS",True)
+exec_dir = sys.executable
+app_name = [i for i in exec_dir.split(os.sep) if i.startswith('QGIS')][0]
+
+# See https://gis.stackexchange.com/a/155852/4972 for details about the prefix
+QgsApplication.setPrefixPath(f"/Applications/{app_name}/Contents/MacOS",True)
 qgs = QgsApplication([], False)
 qgs.initQgis()
 
 # Append the path where processing plugin can be found
-sys.path.append("/Applications/QGIS.app/Contents/Resources/python/plugins")
+sys.path.append(f"/Applications/{app_name}/Contents/Resources/python/plugins")
 
 
 import processing


### PR DESCRIPTION
This PR sets the app name (`QGIS` vs `QGIS-LTR`) in the script paths, based on the interpreter path used to run the script